### PR TITLE
Show skipped directories and branch name in output

### DIFF
--- a/updateRepos.sh
+++ b/updateRepos.sh
@@ -64,6 +64,25 @@ printFailedRepos(){
 
 }
 
+declare -a skippedDirs=()
+
+addSkippedDir(){
+  skippedDirs=("${skippedDirs[@]}" "$1")
+}
+
+printSkippedDirs(){
+  if [ ${#skippedDirs[@]} -gt 0 ]; then
+    cecho b "# ${#skippedDirs[@]} directories skipped:"
+    cecho b "# --------------------------------------"
+    for directory in "${skippedDirs[@]}";
+    do
+      cecho b "# > ${directory}"
+    done
+    cecho b "# --------------------------------------"
+  fi
+
+}
+
 update(){
   clear
   dir=$1;
@@ -91,6 +110,7 @@ update(){
     cecho b "\n"
   else
     cecho y "#### $PWD does not contains a git repository"
+    addSkippedDir ${dir}
   fi
   cd .. ;
 }
@@ -100,6 +120,7 @@ finish(){
   cecho g "########################################";
   cecho g "# DONE! ";
   printUpdatedRepos ${updatedRepos}
+  printSkippedDirs  ${skippedDirs}
   printFailedRepos  ${failedRepos}
   cecho g "########################################";
   cecho g "\nSEE YOU LATER BRO..."

--- a/updateRepos.sh
+++ b/updateRepos.sh
@@ -86,27 +86,26 @@ printSkippedDirs(){
 update(){
   clear
   dir=$1;
-  cd $dir ;
+
+  if [ -d $dir ]; then
+    cd $dir
+  else
+    return
+  fi
+
   if [ -d .git ]; then
     cecho b "# UPDATING => $dir ";
     cecho c "$(git fetch)";
-    git rev-parse --verify develop
+    mainBranchName=$(git remote show origin | grep 'HEAD branch' | cut -d' ' -f5)
     if [ "$?" == "0" ]; then
-      cecho c "$(git checkout 'develop')";
-      cecho c "# Branch develop will be updated"
-    else
-      git rev-parse --verify develop
-      # git rev-parse --verify master
-      if [ "$?" == "0" ]; then
-        cecho c "$(git checkout 'master')";
-        cecho c "# Branch master will be updated"
-      fi
+      cecho c "$(git checkout $mainBranchName)";
+      cecho c "# Branch $mainBranchName will be updated"
     fi
     output=$(git pull)
     status=$?
     cecho c $output;
     if [[ $status != 0 ]]; then cecho r "${dir} failed :("; addFailedRepo ${dir}; fi
-    addUpdatedRepo ${dir}
+    addUpdatedRepo "${dir} ($mainBranchName)"
     cecho b "\n"
   else
     cecho y "#### $PWD does not contains a git repository"
@@ -130,7 +129,7 @@ clear
 cecho g "\t\t---- GIT UPDATER ----"
 if [ "$1" == "-a" ] || [ "$1" == "all" ]; then
   cecho p "\tALL GIT REPOS WILL BE UPDATED\n"
-  for d in */ ; do
+  for d in * ; do
     update $d;
   done
   finish


### PR DESCRIPTION
Hey @devCharles,

I know this an older repo, but this is a nice little tool, was searching for something like this given I always manually pull for a multitude of stale repos. 

I added skipped directories to the output, as well as displaying the branch name in the update repositories. I also am figuring out what the HEAD branch is for a repository using `git remote show origin | grep 'HEAD branch' | cut -d' ' -f5`, as repos often vary between master, main, develop, etc. 

Let me know if you're a fan of the change/if it works for you, and want to merge it.

Thanks